### PR TITLE
Create Apify actor for Perplexity integration

### DIFF
--- a/.actor/actor.json
+++ b/.actor/actor.json
@@ -1,0 +1,16 @@
+{
+  "actorSpecification": 1,
+  "name": "apify-perplexity-bridge",
+  "title": "Apify Perplexity Bridge",
+  "description": "Actor que encaminha prompts ao Perplexity e armazena respostas estruturadas.",
+  "version": "0.1",
+  "buildTag": "latest",
+  "dockerfile": "./Dockerfile",
+  "inputSchema": "./INPUT_SCHEMA.json",
+  "environmentVariables": [
+    {
+      "name": "PERPLEXITY_API_KEY",
+      "value": ""
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+apify_storage/
+.venv/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM apify/actor-python:3.11
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . ./
+
+CMD ["python", "-m", "src.main"]

--- a/INPUT_SCHEMA.json
+++ b/INPUT_SCHEMA.json
@@ -1,0 +1,81 @@
+{
+  "title": "Configuração do prompt",
+  "description": "Parâmetros para enviar prompts ao Perplexity via Actor.",
+  "type": "object",
+  "schemaVersion": 1,
+  "properties": {
+    "prompt": {
+      "title": "Pergunta",
+      "type": "string",
+      "description": "Texto principal a ser enviado ao modelo. Ignorado se 'messages' for preenchido.",
+      "editor": "textarea",
+      "default": "Explique o ecossistema Apify + Perplexity em português."
+    },
+    "systemPrompt": {
+      "title": "Instruções do sistema",
+      "type": "string",
+      "description": "Mensagem opcional de sistema para guiar o modelo.",
+      "editor": "textarea"
+    },
+    "messages": {
+      "title": "Mensagens customizadas",
+      "type": "array",
+      "description": "Lista completa de mensagens a ser enviada para a API do Perplexity.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string",
+            "title": "Role",
+            "enum": ["system", "user", "assistant", "tool"],
+            "default": "user"
+          },
+          "content": {
+            "type": "string",
+            "title": "Conteúdo",
+            "editor": "textarea"
+          }
+        },
+        "required": ["role", "content"]
+      }
+    },
+    "model": {
+      "title": "Modelo",
+      "type": "string",
+      "default": "llama-3.1-sonar-small-128k-online"
+    },
+    "temperature": {
+      "title": "Temperature",
+      "type": "number",
+      "minimum": 0,
+      "maximum": 2,
+      "default": 0.2
+    },
+    "topP": {
+      "title": "Top P",
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "default": 0.95
+    },
+    "maxTokens": {
+      "title": "Limite de tokens",
+      "type": "integer",
+      "minimum": 16,
+      "maximum": 8000
+    },
+    "searchMode": {
+      "title": "Modo de busca",
+      "type": "string",
+      "enum": ["auto", "concise", "copilot", "online", "offline"],
+      "description": "Controla o comportamento da busca híbrida do Perplexity.",
+      "default": "auto"
+    },
+    "returnRaw": {
+      "title": "Salvar resposta bruta",
+      "type": "boolean",
+      "description": "Quando verdadeiro, salva a resposta completa no Key-value store padrão.",
+      "default": false
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,78 @@
+# Apify Perplexity Bridge
+
+Actor do Apify escrito em Python que recebe prompts, chama a API do Perplexity e persiste a resposta estruturada no dataset padrão.
+
+## Estrutura do projeto
+
+```
+.
+├── .actor/actor.json        # Metadados do Actor (nome, schema de input, variáveis)
+├── Dockerfile               # Imagem baseada em apify/actor-python com dependências
+├── INPUT_SCHEMA.json        # Esquema utilizado pela UI do Apify para montar o formulário de input
+├── README.md                # Instruções de uso
+├── requirements.txt         # Dependências Python (apify SDK + cliente Perplexity)
+└── src/
+    └── main.py              # Implementação principal do Actor
+```
+
+## Pré-requisitos
+
+* [Apify CLI](https://docs.apify.com/cli) instalado localmente.
+* Conta no [Perplexity](https://www.perplexity.ai/) com uma chave de API ativa (`PERPLEXITY_API_KEY`).
+
+## Como executar localmente
+
+1. Instale as dependências Python (opcional em execução local fora do runtime Apify):
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Defina a variável `PERPLEXITY_API_KEY` no ambiente.
+
+3. Rode o Actor com a CLI do Apify:
+
+   ```bash
+   apify run --purge
+   ```
+
+   O input pode ser ajustado editando `apify_storage/key_value_stores/default/INPUT.json` ou passando `--input '{"prompt": "Pergunta"}'`.
+
+## Parâmetros de entrada
+
+O Actor aceita os seguintes campos (ver `INPUT_SCHEMA.json` para detalhes):
+
+| Campo         | Tipo      | Descrição |
+|---------------|-----------|-----------|
+| `prompt`      | string    | Pergunta enviada ao modelo. Ignorado se `messages` for informado. |
+| `systemPrompt`| string    | Mensagem de sistema opcional que antecede as demais mensagens. |
+| `messages`    | array     | Lista completa de mensagens para a API do Perplexity. |
+| `model`       | string    | ID do modelo Perplexity. Default `llama-3.1-sonar-small-128k-online`. |
+| `temperature` | number    | Controle de criatividade. Default `0.2`. |
+| `topP`        | number    | Top-p sampling. Default `0.95`. |
+| `maxTokens`   | integer   | Limite máximo de tokens de saída. |
+| `searchMode`  | string    | Ajusta o modo de busca híbrida (`auto`, `online`, etc.). |
+| `returnRaw`   | boolean   | Quando `true`, salva a resposta completa no Key-value store padrão. |
+
+## Saída
+
+Cada execução grava uma entrada no dataset padrão com:
+
+* `prompt` – resumo do prompt enviado.
+* `messages` – mensagens enviadas ao Perplexity.
+* `model` – modelo utilizado.
+* `response` – conteúdo textual retornado.
+* `citations` – citações fornecidas pelo Perplexity (quando disponíveis).
+* `usage` – métricas de tokens consumidos.
+
+Quando `returnRaw` é verdadeiro, a resposta integral também é salva com a chave `PERPLEXITY_COMPLETION` no Key-value store padrão da execução.
+
+## Deploy no Apify
+
+1. Faça login na CLI: `apify login`.
+2. Publique o Actor para o cloud: `apify push`.
+3. No Apify Console, configure a variável secreta `PERPLEXITY_API_KEY` e execute o Actor via UI, schedule ou chamadas `apify call`.
+
+## Licença
+
+MIT.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+apify>=1.7.0
+perplexityai>=0.3.0

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,144 @@
+"""Actor do Apify que envia prompts ao Perplexity."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+from apify import Actor
+from perplexity import Perplexity
+
+DEFAULT_MODEL = "llama-3.1-sonar-small-128k-online"
+VALID_ROLES = {"system", "user", "assistant", "tool"}
+RAW_KEY = "PERPLEXITY_COMPLETION"
+
+
+def _normalise_messages(
+    actor_input: Mapping[str, Any],
+) -> Tuple[List[Dict[str, str]], Optional[str]]:
+    """Cria a lista de mensagens a partir do input fornecido.
+
+    Retorna um tuplo com (messages, prompt_principal).
+    """
+
+    system_prompt = actor_input.get("systemPrompt")
+    explicit_messages = actor_input.get("messages")
+    messages: List[Dict[str, str]] = []
+
+    if explicit_messages:
+        if not isinstance(explicit_messages, Sequence) or isinstance(explicit_messages, (str, bytes)):
+            raise ValueError("O campo 'messages' deve ser uma lista de objetos.")
+
+        for idx, message in enumerate(explicit_messages):
+            if not isinstance(message, Mapping):
+                raise ValueError(
+                    f"A mensagem na posição {idx} deve ser um objeto com 'role' e 'content'."
+                )
+
+            role = str(message.get("role", "")).strip().lower()
+            content = message.get("content")
+
+            if role not in VALID_ROLES:
+                raise ValueError(
+                    f"Role inválido na posição {idx}: '{role}'. Valores aceitos: {sorted(VALID_ROLES)}"
+                )
+            if not isinstance(content, str) or not content.strip():
+                raise ValueError(f"A mensagem na posição {idx} deve possuir 'content' textual.")
+
+            messages.append({"role": role, "content": content})
+
+        if system_prompt:
+            messages.insert(0, {"role": "system", "content": str(system_prompt)})
+
+        first_user = next((m["content"] for m in messages if m["role"] == "user"), None)
+        return messages, first_user
+
+    prompt_text = actor_input.get("prompt")
+    if not isinstance(prompt_text, str) or not prompt_text.strip():
+        raise ValueError("Informe ao menos um 'prompt' ou uma lista de 'messages'.")
+
+    if system_prompt:
+        messages.append({"role": "system", "content": str(system_prompt)})
+
+    messages.append({"role": "user", "content": prompt_text})
+    return messages, prompt_text
+
+
+def _build_request_payload(
+    actor_input: Mapping[str, Any]
+) -> Tuple[Dict[str, Any], Optional[str], List[Dict[str, str]]]:
+    messages, prompt_summary = _normalise_messages(actor_input)
+
+    payload: Dict[str, Any] = {
+        "model": actor_input.get("model") or DEFAULT_MODEL,
+        "messages": messages,
+        "temperature": actor_input.get("temperature", 0.2),
+        "top_p": actor_input.get("topP", 0.95),
+        "search_mode": actor_input.get("searchMode") or "auto",
+    }
+
+    if actor_input.get("maxTokens") is not None:
+        payload["max_tokens"] = int(actor_input["maxTokens"])
+
+    payload = {key: value for key, value in payload.items() if value is not None}
+
+    return payload, prompt_summary, messages
+
+
+async def _call_perplexity(payload: Mapping[str, Any]) -> Any:
+    client = Perplexity()
+    return await asyncio.to_thread(client.chat.completions.create, **payload)
+
+
+async def main() -> None:
+    async with Actor:
+        log = Actor.log
+
+        actor_input: MutableMapping[str, Any] = await Actor.get_input() or {}
+        log.info("Executando Actor Apify -> Perplexity", extra={"input": actor_input})
+
+        payload, prompt_summary, messages = _build_request_payload(actor_input)
+        log.debug("Payload preparado para envio", extra={"payload": payload})
+
+        completion = await _call_perplexity(payload)
+        if hasattr(completion, "model_dump"):
+            completion_dict = completion.model_dump()
+        elif isinstance(completion, Mapping):
+            completion_dict = dict(completion)
+        else:
+            raise TypeError("Resposta inesperada do cliente Perplexity.")
+
+        primary_choice = None
+        choices = completion_dict.get("choices")
+        if isinstance(choices, list) and choices:
+            primary_choice = choices[0]
+
+        response_payload: Any = None
+        if isinstance(primary_choice, Mapping):
+            message_block = primary_choice.get("message")
+            if isinstance(message_block, Mapping):
+                response_payload = message_block.get("content")
+            else:
+                response_payload = message_block
+        else:
+            response_payload = primary_choice
+
+        dataset_item = {
+            "prompt": prompt_summary,
+            "messages": messages,
+            "model": completion_dict.get("model"),
+            "response": response_payload,
+            "citations": completion_dict.get("citations"),
+            "usage": completion_dict.get("usage"),
+        }
+
+        await Actor.push_data(dataset_item)
+        log.info("Resposta registrada no dataset padrão.")
+
+        if actor_input.get("returnRaw"):
+            await Actor.set_value(RAW_KEY, completion_dict)
+            log.info("Resposta completa armazenada no Key-value store padrão.", extra={"key": RAW_KEY})
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- scaffold a Python Apify actor for relaying prompts to the Perplexity API
- add input schema, Dockerfile, and dependency definitions for Apify deployment
- implement actor logic to normalize messages, call Perplexity, and persist results

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d55a8405b0833093c8b533cec1e1d4